### PR TITLE
gyp: fix MagickWand-config usage

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,18 +3,18 @@
     {
       "target_name": "magickwand",
        "sources": [ "src/magickwand.cpp" ],
-       'libraries': [ '<!@(Magick-config --libs)' ],
+       'libraries': [ '<!@(MagickWand-config --libs)' ],
        "conditions": [
         ['OS=="mac"', {
           # cflags on OS X are stupid and have to be defined like this
           'xcode_settings': {
             'OTHER_CFLAGS': [
-              '<!@(Magick-config --cflags)'
+              '<!@(MagickWand-config --cflags)'
             ],
           }
         }, {
           'cflags': [
-            '<!@(Magick-config --cflags)'
+            '<!@(MagickWand-config --cflags)'
           ]
         }]
       ]


### PR DESCRIPTION
This patch should fix the linker issues with MagickWand.

Note there is still a small issue with resolving the 'magickwand.node' file, since gyp will build it at build/Release/magickwand.node
