### PR TITLE
fix build errors on centos 5 with gcc 4.2

### DIFF
--- a/src/magickwand.h
+++ b/src/magickwand.h
@@ -4,6 +4,7 @@
 #define BUILDING_NODE_EXTENSION
 #include <node.h>
 #include <node_buffer.h>
+#include <stdlib.h>
 #include <string.h>
 #include <wand/MagickWand.h>
 


### PR DESCRIPTION
Hi, this request is a patch to fix a compile error with gcc 4.2 on centos 5.

```
resize.cpp: 'free' was not declared in this scope
thumbnail.cpp: 'free' was not declared in this scope
```
